### PR TITLE
Improve release monitor

### DIFF
--- a/generate.php
+++ b/generate.php
@@ -1,16 +1,26 @@
 <?php
 
-if ($argc < 2) {
-    die('Please pass a GitHub token as argument');
-}
-
 $timeStart = microtime(true);
-
 require_once __DIR__ . '/vendor/autoload.php';
 
+// Get token from parameters, CLI or GET
+$token = null;
+if (isset($argc) && !empty($argv[1])) {
+    echo 'Using CLI token</br>';
+    $token = $argv[1];
+}
+if (!empty($_GET['token'])) {
+    echo 'Using GET token</br>';
+    $token = $_GET['token'];
+}
+if (empty($token)) {
+    die('Please pass a GitHub token as argument in the CLI, or using "token" get parameter.');
+}
+
+// Initialize github client and login
 $client = new \Github\Client();
-$token = $argv[1];
 $client->authenticate($token, null, Github\Client::AUTH_HTTP_TOKEN);
+echo 'Login successful</br>';
 
 $branchManager = new \App\PrestaShopModulesReleaseMonitor\BranchManager($client);
 
@@ -32,6 +42,9 @@ function getModules($client): array
 function getClassByNbCommitsAhead(int $nbCommitsAhead): string
 {
     switch ($nbCommitsAhead) {
+        case ($nbCommitsAhead == 0):
+            $trClass = 'success';
+            break;
         case ($nbCommitsAhead > 0 && $nbCommitsAhead <= 25):
             $trClass = 'light';
             break;
@@ -49,52 +62,110 @@ function getClassByNbCommitsAhead(int $nbCommitsAhead): string
     return 'table-' . $trClass;
 }
 
+echo 'Fetching list of modules</br>';
 $modulesToProcess = getModules($client);
-$template = file_get_contents(__DIR__.'/src/template.tpl');
+// $modulesToProcess = ['blockreassurance', 'statsstock'];
+echo 'Module list initialized, found ' . count($modulesToProcess) . ' module</br>';
+echo 'Rendering table</br>';
 
+// Data we will use to render an overview
+$notifications = [
+    'not_published' => [],
+    'unclosed_milestone' => [],
+    'no_next_milestone' => [],
+    'old_milestones' => [],
+];
+
+$template = file_get_contents(__DIR__.'/src/template.tpl');
 $tableRows = [];
 $i = 1;
 
+// Let's go through all prestashop modules and process data we need
+foreach ($modulesToProcess as $moduleName) {
 
-foreach ($modulesToProcess as $moduleToProcess) {
-    $repositoryName = $moduleToProcess;
-    $data = $branchManager->getReleaseData($repositoryName);
-    $nbCommitsAhead = $data['ahead'];
+    // Get data about repository
+    $data = $branchManager->getReleaseData($moduleName);
 
-    $trClass = getClassByNbCommitsAhead($nbCommitsAhead);
-
-    $link = $assignee = '';
-
-    if ($data['pullRequest']) {
-        $link = '<a href="'.$data['pullRequest']['link'].'">#PR' . $data['pullRequest']['number'] . '</a>';
-        $assignee = $data['pullRequest']['assignee'];
-    }
-
-    if ($nbCommitsAhead == 0) {
-        $tableRows[] = [
-            'html' => '<tr class="table-success">
-              <th scope="row">'.$i.'</th>
-              <td><a href="https://github.com/prestashop/'.$repositoryName.'">'.$repositoryName.'</a></td>
-              <td>NO</td>
-              <td>0</td>
-              <td>' . $data['releaseDate'] . '</td>
-              <td>' . $link . ' ' . $assignee . '</td>
-            </tr>',
-            'ahead' => 0,
-        ];
+    // Process info about last release
+    $lastReleaseInformation = [];
+    if (!empty($data['latestRelease'])) {
+        $lastReleaseInformation[] = 'Name: <a href="' . $data['latestRelease']['url'] . '">' . $data['latestRelease']['name'] . '</a>';
+        $lastReleaseInformation[] = 'Tag: ' . $data['latestRelease']['tag'];
+        if (empty($data['latestRelease']['date_published'])) {
+            $lastReleaseInformation[] = '<strong style="color:red;">Release not published yet!</strong>';
+            $notifications['not_published'][] = $moduleName;
+        }
     } else {
-        $tableRows[] = [
-            'html' =>'<tr class="'.$trClass.'">
-              <th scope="row">'.$i.'</th>
-              <td><a href="https://github.com/prestashop/'.$repositoryName.'">'.$repositoryName.'</a></td>
-              <td>YES</td>
-              <td>' . $data['ahead'] . '</td>
-              <td>' . $data['releaseDate'] . '</td>
-              <td>' . $link . ' ' . $assignee . '</td>
-            </tr>',
-            'ahead' => $data['ahead'],
-        ];
+        $lastReleaseInformation[] = 'No release yet';
     }
+
+    // Add info about milestones to last release
+    $lastMilestone = '';
+    if (!empty($data['milestoneInformation']['last'])) {
+        $lastMilestone = 'Milestone: <a href="' . $data['milestoneInformation']['last'][0]['url'] . '">
+        ' . $data['milestoneInformation']['last'][0]['title'] . '</a>';
+        if ($data['milestoneInformation']['last'][0]['state'] == 'open') {
+            $lastMilestone .= ', <strong style="color:red;">NOT CLOSED!</strong>';
+            $notifications['unclosed_milestone'][] = $moduleName;
+        }
+    } else {
+        $lastMilestone = 'Not found';
+    }
+    $lastReleaseInformation[] = $lastMilestone;
+
+    // Last release date
+    $lastReleaseDate = (!empty($data['latestRelease']) ? $data['latestRelease']['date'] : 'NA');
+
+    // Needs release?
+    $needsRelease = ($data['ahead'] > 0 ? 'YES' : 'NO');
+
+    // Next release information
+    $nextReleaseInformation = [];
+    if (!empty($data['pullRequest'])) {
+        $nextReleaseInformation[] = 
+            'PR: <a href="'. $data['pullRequest']['link'] . '">
+            #' . $data['pullRequest']['number'] . ' - ' . $data['pullRequest']['title'] . 
+            '</a>';
+        if ($data['pullRequest']['waitingForQa']) {
+            $nextReleaseInformation[] = '<strong style="color:green;">Status: Waiting for QA</strong>';
+        } else {
+            $nextReleaseInformation[] = '<strong style="color:red;">Status: Needs action</strong>';
+        }
+        if (!empty($data['pullRequest']['assignee'])) {
+            $nextReleaseInformation[] = 'Assignee: ' . $data['pullRequest']['assignee'];
+        }
+    }
+
+    // Add info about next milestones
+    if (!empty($data['milestoneInformation']['next'])) {
+        $tmp = [];
+        foreach ($data['milestoneInformation']['next'] as $m) {
+            $tmp[] = '<a href="' . $m['url'] . '">' . $m['title'] . '</a>';
+        }
+        $nextReleaseInformation[] = 'Milestone(s): ' . implode(", ", $tmp);
+    } else {
+        $nextReleaseInformation[] = '<strong style="color:red;">Milestone not found!</strong>';
+        $notifications['no_next_milestone'][] = $moduleName;
+    }
+
+    // Info about old milestones
+    if (!empty($data['milestoneInformation']['old'])) {
+        $notifications['old_milestones'][] = $moduleName;
+    }
+
+    // Render the table row
+    $tableRows[] = [
+        'html' => '<tr class="' . getClassByNbCommitsAhead($data['ahead']) . '">
+            <th scope="row">'.$i.'</th>
+            <td><a href="https://github.com/prestashop/' . $moduleName . '">' . $moduleName . '</a></td>
+            <td>' . $needsRelease . '</td>
+            <td>' . $data['ahead'] . '</td>
+            <td>' . $lastReleaseDate . '</td>
+            <td>' . implode('<br/>', $lastReleaseInformation) . '</td>
+            <td>' . implode('<br/>', $nextReleaseInformation) . '</td>
+        </tr>',
+        'ahead' => $data['ahead'],
+    ];
 
     uasort($tableRows, function ($a, $b) {
         if ($a['ahead'] == $b['ahead']) {
@@ -111,19 +182,47 @@ foreach ($modulesToProcess as $moduleToProcess) {
     $i++;
 }
 
+// Process notifications
+$notifications_html = '';
+if (!empty($notifications['not_published'])) {
+    $notifications_html .= '<div class="alert alert-warning" role="alert">
+        Modules <strong>' . implode(', ', $notifications['not_published']) . '</strong> have releases created, but not published.
+    </div>';
+}
+if (!empty($notifications['unclosed_milestone'])) {
+    $notifications_html .= '<div class="alert alert-warning" role="alert">
+        Modules <strong>' . implode(', ', $notifications['unclosed_milestone']) . '</strong> have unclosed milestones, close them.
+    </div>';
+}
+if (!empty($notifications['no_next_milestone'])) {
+    $notifications_html .= '<div class="alert alert-warning" role="alert">
+        Modules <strong>' . implode(', ', $notifications['no_next_milestone']) . '</strong> don\'t have next milestones.
+    </div>';
+}
+if (!empty($notifications['old_milestones'])) {
+    $notifications_html .= '<div class="alert alert-warning" role="alert">
+        Modules <strong>' . implode(', ', $notifications['old_milestones']) . '</strong> have some old unclosed milestones.
+    </div>';
+}
+
+echo 'Rendering finished, saving to <a href="docs/index.html">index.html</a></br>';
+
 file_put_contents(
     __DIR__ . '/docs/index.html',
     str_replace(
         [
-            '{%%placeholder%%}',
+            '{%%tableBody%%}',
             '{%%latestUpdateDate%%}',
+            '{%%notifications%%}',
         ],
         [
             implode('', $tableContent),
             date('l, j F Y H:i'),
+            $notifications_html,
         ],
         $template
     )
 );
 
-die('Generated in ' . (microtime(true) - $timeStart) . ' seconds');
+echo 'Generated in ' . (microtime(true) - $timeStart) . ' seconds</br>';
+die();

--- a/generate.php
+++ b/generate.php
@@ -122,9 +122,9 @@ foreach ($modulesToProcess as $moduleName) {
     // Next release information
     $nextReleaseInformation = [];
     if (!empty($data['pullRequest'])) {
-        $nextReleaseInformation[] = 
+        $nextReleaseInformation[] =
             'PR: <a href="'. $data['pullRequest']['link'] . '">
-            #' . $data['pullRequest']['number'] . ' - ' . $data['pullRequest']['title'] . 
+            #' . $data['pullRequest']['number'] . ' - ' . $data['pullRequest']['title'] .
             '</a>';
         if ($data['pullRequest']['waitingForQa']) {
             $nextReleaseInformation[] = '<strong style="color:green;">Status: Waiting for QA</strong>';

--- a/src/BranchManager.php
+++ b/src/BranchManager.php
@@ -52,8 +52,8 @@ class BranchManager
 
         // Get all milestones from this repository
         $milestones = $this->client->api('issue')->milestones()->all(
-            'prestashop', 
-            $repositoryName, 
+            'prestashop',
+            $repositoryName,
             ['state' => 'all']
         );
 
@@ -71,7 +71,7 @@ class BranchManager
                     ];
 
                 // Try to find next milestone higher than the last released version
-                } else if (version_compare($milestone['title'], $milestoneVersion, '>') && $milestone['state'] == 'open') {
+                } elseif (version_compare($milestone['title'], $milestoneVersion, '>') && $milestone['state'] == 'open') {
                     $milestoneInformation['next'][] = [
                         'title' => $milestone['title'],
                         'state' => $milestone['state'],
@@ -79,7 +79,7 @@ class BranchManager
                     ];
 
                 // We list some old milestones that are still open
-                } else if ($milestone['state'] == 'open') {
+                } elseif ($milestone['state'] == 'open') {
                     $milestoneInformation['old'][] = [
                         'title' => $milestone['title'],
                         'state' => $milestone['state'],
@@ -148,9 +148,9 @@ class BranchManager
             }
 
             $openPullRequest = [
-                'link' => $openPullRequests[0]['html_url'], 
-                'number' => $openPullRequests[0]['number'], 
-                'title' => $openPullRequests[0]['title'], 
+                'link' => $openPullRequests[0]['html_url'],
+                'number' => $openPullRequests[0]['number'],
+                'title' => $openPullRequests[0]['title'],
                 'assignee' => $assignee,
                 'waitingForQa' => $waitingForQa,
             ];

--- a/src/BranchManager.php
+++ b/src/BranchManager.php
@@ -23,20 +23,84 @@ class BranchManager
 
     /**
      * @param string $repositoryName
-     * @return string|null null if failed to find base branch
+     * @return array|null Repository data
      *
      * Inspired by https://github.com/PrestaShop/presthubot ModuleChecker::findReleaseStatus()
      */
     public function getReleaseData($repositoryName)
     {
+        // Try to get data about latest release of this module
+        $latestRelease = null;
         try {
             $release = $this->client->api('repo')->releases()->latest('prestashop', $repositoryName);
-            $date = new DateTime($release['created_at']);
-            $releaseDate = $date->format('Y-m-d H:i:s');
+            $latestRelease = [
+                'date' => (new DateTime($release['created_at']))->format('Y-m-d H:i:s'),
+                'name' => $release['name'],
+                'tag' => $release['tag_name'],
+                'url' => $release['html_url'],
+                'date_published' => (new DateTime($release['published_at']))->format('Y-m-d H:i:s'),
+            ];
         } catch (Exception $e) {
-            $releaseDate = 'NA';
         }
 
+        // Milestone information
+        $milestoneInformation = [
+            'last' => [],
+            'next' => [],
+            'old' => [],
+        ];
+
+        // Get all milestones from this repository
+        $milestones = $this->client->api('issue')->milestones()->all(
+            'prestashop', 
+            $repositoryName, 
+            ['state' => 'all']
+        );
+
+        // Try to fetch milestone for current release
+        if (!empty($latestRelease)) {
+            // Remove v from release name to get related milestone
+            $milestoneVersion = str_replace("v", "", $latestRelease['name']);
+            foreach ($milestones as $milestone) {
+                // If we have a milestone with the same name as last release tag
+                if ($milestone['title'] == $milestoneVersion) {
+                    $milestoneInformation['last'][] = [
+                        'title' => $milestone['title'],
+                        'state' => $milestone['state'],
+                        'url' => $milestone['html_url'],
+                    ];
+
+                // Try to find next milestone higher than the last released version
+                } else if (version_compare($milestone['title'], $milestoneVersion, '>') && $milestone['state'] == 'open') {
+                    $milestoneInformation['next'][] = [
+                        'title' => $milestone['title'],
+                        'state' => $milestone['state'],
+                        'url' => $milestone['html_url'],
+                    ];
+
+                // We list some old milestones that are still open
+                } else if ($milestone['state'] == 'open') {
+                    $milestoneInformation['old'][] = [
+                        'title' => $milestone['title'],
+                        'state' => $milestone['state'],
+                        'url' => $milestone['html_url'],
+                    ];
+                }
+            }
+        // If module was not released yet
+        } else {
+            foreach ($milestones as $milestone) {
+                if ($milestone['state'] == 'open') {
+                    $milestoneInformation['next'][] = [
+                        'title' => $milestone['title'],
+                        'state' => $milestone['state'],
+                        'url' => $milestone['html_url'],
+                    ];
+                }
+            }
+        }
+
+        // Get branch data, we need to know how many commits it's ahead etc.
         $references = $this->client->api('gitData')->references()->branches('prestashop', $repositoryName);
 
         $devBranchData = $masterBranchData = [];
@@ -69,11 +133,27 @@ class BranchManager
             $devLastCommitSha
         );
 
+        // Get next release PR information
         $openPullRequests = $this->client->api('pull_request')->all('prestashop', $repositoryName, array('state' => 'open', 'base' => $usedBranch));
-
-        if ($openPullRequests) {
+        if (!empty($openPullRequests)) {
+            // QA assigned
             $assignee = isset($openPullRequests[0]['assignee']['login']) ? $openPullRequests[0]['assignee']['login'] : '';
-            $openPullRequest = ['link' => $openPullRequests[0]['html_url'], 'number' => $openPullRequests[0]['number'], 'assignee' => $assignee];
+
+            // Waiting for QA?
+            $waitingForQa = false;
+            foreach ($openPullRequests[0]['labels'] as $label) {
+                if ($label['name'] == 'waiting for QA') {
+                    $waitingForQa = true;
+                }
+            }
+
+            $openPullRequest = [
+                'link' => $openPullRequests[0]['html_url'], 
+                'number' => $openPullRequests[0]['number'], 
+                'title' => $openPullRequests[0]['title'], 
+                'assignee' => $assignee,
+                'waitingForQa' => $waitingForQa,
+            ];
         } else {
             $openPullRequest = false;
         }
@@ -81,8 +161,9 @@ class BranchManager
         return [
             'behind' => $comparison['behind_by'],
             'ahead' => $comparison['ahead_by'],
-            'releaseDate' => $releaseDate,
+            'latestRelease' => $latestRelease,
             'pullRequest' => $openPullRequest,
+            'milestoneInformation' => $milestoneInformation,
         ];
     }
 }

--- a/src/template.tpl
+++ b/src/template.tpl
@@ -37,7 +37,10 @@
       <span class="badge bg-primary">Latest update: {%%latestUpdateDate%%}</span>
     </div>
 
-    <div class="container">
+    <div class="container-fluid">
+
+      {%%notifications%%}
+
       <table class="table table-striped table-bordered" id="modules">
         <thead>
           <tr>
@@ -45,12 +48,13 @@
             <th scope="col">Module name</th>
             <th scope="col">Need release?</th>
             <th scope="col">Commits ahead</th>
-            <th scope="col">Last release date</th>
-            <th scope="col">Pull Request</th>
+            <th scope="col">Last release</th>
+            <th scope="col">Last release information</th>
+            <th scope="col">Next release information</th>
           </tr>
         </thead>
         <tbody>
-          {%%placeholder%%}
+          {%%tableBody%%}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | See below
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Download repo, composer install on Linux/WSL, run 
| Possible impacts? | 

### New features
- Live demo - https://danielhlavacek.cz/_files/monitor.html
- Added a possibility to run this by passing a token in a get parameter.
- Added information about last release version, its tag, about its related milestone.
- Added a check if that milestone is properly closed.
- Added next release information, more info about the PR, its name, its status with a color, info about next milestones.
- Added checks about open milestones that are older than last release.
- Added warnings on top for important things  that must be solved.
- Added colors to important things in the list.

### How to test
- Download repo, `composer install` on Linux/WSL
- Get token here - https://github.com/settings/personal-access-tokens/new
- Run in web browser using `generate.php?token=yourtoken` or in CLI by `php generate yourtoken`