### PR TITLE
Improve release monitor

### DIFF
--- a/src/BranchManager.php
+++ b/src/BranchManager.php
@@ -32,14 +32,20 @@ class BranchManager
         // Try to get data about latest release of this module
         $latestRelease = null;
         try {
-            $release = $this->client->api('repo')->releases()->latest('prestashop', $repositoryName);
-            $latestRelease = [
-                'date' => (new DateTime($release['created_at']))->format('Y-m-d H:i:s'),
-                'name' => $release['name'],
-                'tag' => $release['tag_name'],
-                'url' => $release['html_url'],
-                'date_published' => (new DateTime($release['published_at']))->format('Y-m-d H:i:s'),
-            ];
+            $release = $this->client->api('repo')->releases()->latest(
+                'prestashop',
+                $repositoryName,
+                
+            );
+            if (!empty($release)) {
+                $latestRelease = [
+                    'date' => (new DateTime($release['created_at']))->format('Y-m-d H:i:s'),
+                    'name' => $release['name'],
+                    'tag' => $release['tag_name'],
+                    'url' => $release['html_url'],
+                    'date_published' => (new DateTime($release['published_at']))->format('Y-m-d H:i:s'),
+                ];
+            }
         } catch (Exception $e) {
         }
 
@@ -164,6 +170,42 @@ class BranchManager
             'latestRelease' => $latestRelease,
             'pullRequest' => $openPullRequest,
             'milestoneInformation' => $milestoneInformation,
+            'moduleFileVersion' => $this->getModuleFileVersion($repositoryName),
+            'configFileVersion' => $this->getConfigFileVersion($repositoryName),
         ];
+    }
+
+    public function getModuleFileVersion($repositoryName)
+    {
+        $data = @file_get_contents('https://raw.githubusercontent.com/PrestaShop/' . $repositoryName . '/dev/' . $repositoryName . '.php');
+        if (empty($data)) {
+            return null;
+        }
+
+        $data = explode('$this->version', $data)[1];
+        $data = explode(';', $data)[0];
+        $data = preg_replace('/[^0-9.]/', '', $data);
+        if (empty($data)) {
+            return null;
+        }
+
+        return $data;
+    }
+
+    public function getConfigFileVersion($repositoryName)
+    {
+        $data = @file_get_contents('https://raw.githubusercontent.com/PrestaShop/' . $repositoryName . '/dev/config.xml');
+        if (empty($data)) {
+            return null;
+        }
+
+        $data = explode('<version>', $data)[1];
+        $data = explode('</version>', $data)[0];
+        $data = preg_replace('/[^0-9.]/', '', $data);
+        if (empty($data)) {
+            return null;
+        }
+
+        return $data;
     }
 }

--- a/src/BranchManager.php
+++ b/src/BranchManager.php
@@ -35,7 +35,6 @@ class BranchManager
             $release = $this->client->api('repo')->releases()->latest(
                 'prestashop',
                 $repositoryName,
-                
             );
             if (!empty($release)) {
                 $latestRelease = [
@@ -65,8 +64,8 @@ class BranchManager
 
         // Try to fetch milestone for current release
         if (!empty($latestRelease)) {
-            // Remove v from release name to get related milestone
-            $milestoneVersion = str_replace("v", "", $latestRelease['name']);
+            // Get milestone name to search for
+            $milestoneVersion = preg_replace('/[^0-9.]/', '', $latestRelease['name']);
             foreach ($milestones as $milestone) {
                 // If we have a milestone with the same name as last release tag
                 if ($milestone['title'] == $milestoneVersion) {


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | See below
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Download repo, composer install on Linux/WSL, run 
| Possible impacts? | 

### New features
- Live demo - https://danielhlavacek.cz/_files/monitor.html
- Fix CLI output.
- Fix parsing milestone name - used regex for it.
- Report multiple milestones open.
- Check versions in module file and config.xml, report mismatch.
- Remove Corp modules that should not be in that list, it will be solved later.

### How to test
- Download repo, `composer install` on Linux/WSL
- Get token here - https://github.com/settings/personal-access-tokens/new
- Run in web browser using `generate.php?token=yourtoken` or in CLI by `php generate yourtoken`

### How does it look
![versions](https://user-images.githubusercontent.com/6097524/212677851-5be4c574-8273-4c45-81e3-7e58cc0b58cf.jpg)